### PR TITLE
Update Dockerfile add curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM --platform=linux/amd64 rust:1.85-slim-bookworm as builder
 
 WORKDIR /usr/src/kairei
-RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y pkg-config libssl-dev ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # Copy Cargo files for dependency caching
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
#246 
* Add curl install for build
* It is needed swagger-ui crate install
```
utoipa-swagger-ui-9.0.0/build.rs:219:50:
--
672 | failed to download Swagger UI: Custom { kind: NotFound, error: "`curl` command not found" }
```
