### PR TITLE
Update Tokenizer error safe

### DIFF
--- a/kairei-core/src/ast.rs
+++ b/kairei-core/src/ast.rs
@@ -607,6 +607,7 @@ use proc_macro2::TokenStream;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::tokenizer::token::TokenizerError;
 use crate::type_checker::TypeCheckError;
 
 // リクエストオプション
@@ -968,6 +969,8 @@ pub enum ASTError {
     ASTNotFound(String),
     #[error("Type check error: {0}")]
     TypeCheckError(#[from] TypeCheckError),
+    #[error("Tokenization error: {0}")]
+    TokenizeError(#[from] TokenizerError),
 }
 
 pub type ASTResult<T> = Result<T, ASTError>;

--- a/kairei-core/src/ast_registry.rs
+++ b/kairei-core/src/ast_registry.rs
@@ -115,7 +115,7 @@ impl AstRegistry {
     pub async fn create_ast_from_dsl(&self, dsl: &str) -> ASTResult<ast::Root> {
         // 1. Tokenization: Convert DSL string into tokens
         let mut tokenizer = tokenizer::token::Tokenizer::new();
-        let tokens = tokenizer.tokenize(dsl).unwrap();
+        let tokens = tokenizer.tokenize(dsl).map_err(ASTError::from)?;
 
         // 2. Preprocessing: Apply token transformations
         let preprocessor = preprocessor::TokenPreprocessor::default();


### PR DESCRIPTION
* Tokenize error rise panic in ast_registry.
* It is possible panic in system.parse_dsl.
* Support Tokenize Error to Ast Error.