### PR TITLE
Add DocParserExt trait for self-documenting DSL parsers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@
 - **Error Messages**: Make error messages clear and actionable
 - **Event-Driven**: Follow event-driven architecture patterns in agent communication
 
+## Quick Reference
+- **docs/quick_reference/index.md** This guide provides a quick overview
+
 ## Repository Structure
 - **src/**: Core source code
   - **analyzer/**: DSL parsing and analysis
@@ -44,7 +47,7 @@
    - Title/headline
    - Background/context
    - Goals/objectives
-   - Implementation details or approach
+   - Clear interface/implement approach/core logic
    - Benefits/outcomes
 
 3. Standard labels for reference:
@@ -59,6 +62,7 @@ The `.claude_workspace/` directory is a dedicated workspace for Claude to:
 - Store temporary content like issue drafts, documentation, etc.
 - Test ideas before implementing them in the main repository
 - The directory is ignored by git (via .gitignore)
+- Under the top level of repository (it is safe, .gitignore contains)
 
 ## GitHub CLI Commands
 ### PR and Issue Management

--- a/examples/doc_parser.rs
+++ b/examples/doc_parser.rs
@@ -1,0 +1,97 @@
+use kairei_core::analyzer::prelude::*;
+use kairei_core::analyzer::{DocParserExt, ParserCategory, ParserDocumentation};
+use kairei_core::ast;
+use kairei_core::tokenizer::token::Token;
+
+/// An example of how to document the `parse_expression` parser
+pub fn documented_parse_expression() -> impl DocParserExt<Token, ast::Expression> {
+    // Create the original parser
+    let expression_parser = with_context(lazy(parse_binary_expression), "expression");
+    
+    // Create documentation for the parser
+    let documentation = DocBuilder::new("parse_expression", ParserCategory::Expression)
+        .description("Parses a complete expression in the KAIREI DSL")
+        .example("x + 5")
+        .example("foo(bar)")
+        .example("think(\"What is the weather like?\")")
+        .related_parser("parse_binary_expression")
+        .related_parser("parse_primary")
+        .build();
+    
+    // Wrap the parser with documentation
+    document(expression_parser, documentation)
+}
+
+/// An example of how to document the `parse_think` parser
+pub fn documented_parse_think() -> impl DocParserExt<Token, ast::Expression> {
+    // Create the original parser
+    let think_parser = with_context(
+        choice(vec![
+            Box::new(parse_think_multiple()),
+            Box::new(parse_think_single()),
+        ]),
+        "think",
+    );
+    
+    // Create documentation for the parser
+    let documentation = DocBuilder::new("parse_think", ParserCategory::Expression)
+        .description("Parses a think expression for LLM invocation")
+        .example("think(\"What is the capital of France?\")")
+        .example("think(\"Summarize this text\", text)")
+        .example("think(prompt: \"Generate ideas\", context: data) with { model: \"gpt-4\" }")
+        .related_parser("parse_think_single")
+        .related_parser("parse_think_multiple")
+        .related_parser("parse_think_attributes")
+        .build();
+    
+    // Wrap the parser with documentation
+    document(think_parser, documentation)
+}
+
+/// Function that shows how to extract and use documentation
+pub fn example_documentation_usage() {
+    // Create a documented parser
+    let parser = documented_parse_think();
+    
+    // Access its documentation
+    let doc = parser.documentation();
+    
+    println!("Parser: {}", doc.name);
+    println!("Category: {}", doc.category);
+    println!("Description: {}", doc.description);
+    
+    println!("\nExamples:");
+    for (i, example) in doc.examples.iter().enumerate() {
+        println!("  {}. {}", i + 1, example);
+    }
+    
+    println!("\nRelated parsers:");
+    for related in &doc.related_parsers {
+        println!("  - {}", related);
+    }
+}
+
+/// A simplified example of how to collect documentation from parsers
+pub fn collect_parser_documentation() -> Vec<ParserDocumentation> {
+    let mut docs = Vec::new();
+    
+    // Register documented parsers
+    let parsers: Vec<Box<dyn DocParserExt<Token, ast::Expression>>> = vec![
+        Box::new(documented_parse_expression()),
+        Box::new(documented_parse_think()),
+    ];
+    
+    // Collect documentation
+    for parser in parsers {
+        docs.push(parser.documentation().clone());
+    }
+    
+    docs
+}
+
+fn main() {
+    example_documentation_usage();
+    
+    let all_docs = collect_parser_documentation();
+    println!("\nCollected {} parser documentation entries", all_docs.len());
+}

--- a/kairei-core/src/analyzer/doc_parser.rs
+++ b/kairei-core/src/analyzer/doc_parser.rs
@@ -231,7 +231,7 @@ impl DocBuilder {
 }
 
 /// Helper functions for creating documented parsers.
-
+///
 /// Create a documented parser with the provided parser and documentation.
 ///
 /// # Arguments
@@ -339,15 +339,15 @@ mod tests {
     fn test_doc_parser_delegates_parsing() {
         // Create a simple parser
         let parser = Equal::new(42);
-        
+
         // Create documentation
         let documentation = DocBuilder::new("equal_42", ParserCategory::Expression)
             .description("Parses the integer 42")
             .build();
-        
+
         // Create a documented parser
         let doc_parser = DocParser::new(parser, documentation);
-        
+
         // Test that parsing is correctly delegated
         let input = &[42, 43, 44];
         assert_eq!(doc_parser.parse(input, 0), Ok((1, 42)));
@@ -357,14 +357,14 @@ mod tests {
     #[test]
     fn test_doc_parser_provides_documentation() {
         let parser = Equal::new(42);
-        
+
         let documentation = DocBuilder::new("equal_42", ParserCategory::Expression)
             .description("Parses the integer 42")
             .example("42")
             .build();
-        
+
         let doc_parser = DocParser::new(parser, documentation);
-        
+
         // Test that we can access the documentation
         let doc = doc_parser.documentation();
         assert_eq!(doc.name, "equal_42");
@@ -384,7 +384,7 @@ mod tests {
             .related_parser("other_parser")
             .related_parsers(vec!["parser1", "parser2"])
             .build();
-        
+
         assert_eq!(doc.name, "test_parser");
         assert_eq!(doc.description, "A test parser");
         assert_eq!(
@@ -401,15 +401,14 @@ mod tests {
     #[test]
     fn test_helper_functions() {
         let parser = Equal::new(42);
-        
+
         // Test document_expression
-        let doc_expr = document_expression(
-            parser.clone(),
-            "equal_42",
-            "Parses the integer 42",
+        let doc_expr = document_expression(parser.clone(), "equal_42", "Parses the integer 42");
+        assert_eq!(
+            doc_expr.documentation().category,
+            ParserCategory::Expression
         );
-        assert_eq!(doc_expr.documentation().category, ParserCategory::Expression);
-        
+
         // Test document_statement
         let doc_stmt = document_statement(
             parser.clone(),
@@ -417,15 +416,18 @@ mod tests {
             "Parses the integer 42 as a statement",
         );
         assert_eq!(doc_stmt.documentation().category, ParserCategory::Statement);
-        
+
         // Test document_handler
         let doc_handler = document_handler(
             parser.clone(),
             "equal_42_handler",
             "Parses the integer 42 as a handler",
         );
-        assert_eq!(doc_handler.documentation().category, ParserCategory::Handler);
-        
+        assert_eq!(
+            doc_handler.documentation().category,
+            ParserCategory::Handler
+        );
+
         // Test document_definition
         let doc_def = document_definition(
             parser.clone(),

--- a/kairei-core/src/analyzer/doc_parser.rs
+++ b/kairei-core/src/analyzer/doc_parser.rs
@@ -19,8 +19,8 @@ pub enum ParserCategory {
     Handler,
     /// Type parsers (string, number, bool, etc.)
     Type,
-    /// World parsers (world, agent, etc.)
-    World,
+    /// Definition parsers for top-level constructs (world, agent, sistence, etc.)
+    Definition,
     /// Other categories not fitting the main ones
     Other(String),
 }
@@ -32,7 +32,7 @@ impl fmt::Display for ParserCategory {
             ParserCategory::Statement => write!(f, "Statement"),
             ParserCategory::Handler => write!(f, "Handler"),
             ParserCategory::Type => write!(f, "Type"),
-            ParserCategory::World => write!(f, "World"),
+            ParserCategory::Definition => write!(f, "Definition"),
             ParserCategory::Other(name) => write!(f, "{}", name),
         }
     }
@@ -308,6 +308,27 @@ where
     DocParser::new(parser, doc)
 }
 
+/// Create a documented definition parser for top-level constructs.
+///
+/// # Arguments
+///
+/// * `parser` - The definition parser to document
+/// * `name` - The name of the parser
+/// * `description` - A description of what the parser does
+pub fn document_definition<P, I, O>(
+    parser: P,
+    name: impl Into<String>,
+    description: impl Into<String>,
+) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    let doc = DocBuilder::new(name, ParserCategory::Definition)
+        .description(description)
+        .build();
+    DocParser::new(parser, doc)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -404,5 +425,13 @@ mod tests {
             "Parses the integer 42 as a handler",
         );
         assert_eq!(doc_handler.documentation().category, ParserCategory::Handler);
+        
+        // Test document_definition
+        let doc_def = document_definition(
+            parser.clone(),
+            "equal_42_definition",
+            "Parses the integer 42 as a definition",
+        );
+        assert_eq!(doc_def.documentation().category, ParserCategory::Definition);
     }
 }

--- a/kairei-core/src/analyzer/doc_parser.rs
+++ b/kairei-core/src/analyzer/doc_parser.rs
@@ -1,0 +1,408 @@
+//! # Documentation Parser Extensions
+//!
+//! This module provides extension traits and implementations to make parsers
+//! self-documenting. This allows the system to generate comprehensive
+//! documentation for the KAIREI DSL based on the actual parser implementations.
+
+use crate::analyzer::core::{ParseResult, Parser};
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Parser category indicating what part of the DSL the parser handles.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ParserCategory {
+    /// Expression parsers (values, operations, etc.)
+    Expression,
+    /// Statement parsers (control flow, assignments, etc.)
+    Statement,
+    /// Handler parsers (answer, observe, react, etc.)
+    Handler,
+    /// Type parsers (string, number, bool, etc.)
+    Type,
+    /// World parsers (world, agent, etc.)
+    World,
+    /// Other categories not fitting the main ones
+    Other(String),
+}
+
+impl fmt::Display for ParserCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParserCategory::Expression => write!(f, "Expression"),
+            ParserCategory::Statement => write!(f, "Statement"),
+            ParserCategory::Handler => write!(f, "Handler"),
+            ParserCategory::Type => write!(f, "Type"),
+            ParserCategory::World => write!(f, "World"),
+            ParserCategory::Other(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+/// Documentation metadata for a parser.
+#[derive(Debug, Clone)]
+pub struct ParserDocumentation {
+    /// The name of the parser (e.g., "parse_expression", "parse_logical_or")
+    pub name: String,
+    /// A description of what the parser does
+    pub description: String,
+    /// The category this parser belongs to
+    pub category: ParserCategory,
+    /// Examples of valid syntax this parser can handle
+    pub examples: Vec<String>,
+    /// Optional deprecation notice if this parser is deprecated
+    pub deprecated: Option<String>,
+    /// Related parsers (e.g., sub-parsers or alternative parsers)
+    pub related_parsers: Vec<String>,
+}
+
+impl Default for ParserDocumentation {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            description: String::new(),
+            category: ParserCategory::Other("Uncategorized".to_string()),
+            examples: Vec::new(),
+            deprecated: None,
+            related_parsers: Vec::new(),
+        }
+    }
+}
+
+/// Extension trait for parsers that provides documentation metadata.
+///
+/// This trait allows parsers to describe themselves with human-readable
+/// documentation that can be collected and used to generate DSL documentation.
+pub trait DocParserExt<I, O>: Parser<I, O> {
+    /// Get the documentation for this parser.
+    fn documentation(&self) -> &ParserDocumentation;
+}
+
+/// A wrapper that adds documentation to an existing parser.
+///
+/// This wrapper implements the `DocParserExt` trait while delegating the actual
+/// parsing to the wrapped parser, allowing documentation to be attached to any
+/// parser without changing its behavior.
+#[derive(Clone)]
+pub struct DocParser<P, I, O> {
+    /// The parser being documented
+    parser: P,
+    /// Documentation metadata for this parser
+    documentation: ParserDocumentation,
+    _phantom: PhantomData<(I, O)>,
+}
+
+impl<P, I, O> DocParser<P, I, O> {
+    /// Create a new documented parser wrapping the given parser.
+    ///
+    /// # Arguments
+    ///
+    /// * `parser` - The parser to wrap with documentation
+    /// * `documentation` - Documentation metadata for the parser
+    pub fn new(parser: P, documentation: ParserDocumentation) -> Self {
+        Self {
+            parser,
+            documentation,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<P, I, O> Parser<I, O> for DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    /// Delegates parsing to the wrapped parser.
+    fn parse(&self, input: &[I], pos: usize) -> ParseResult<O> {
+        self.parser.parse(input, pos)
+    }
+}
+
+impl<P, I, O> DocParserExt<I, O> for DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    /// Returns the documentation for this parser.
+    fn documentation(&self) -> &ParserDocumentation {
+        &self.documentation
+    }
+}
+
+/// Builder for creating parser documentation with a fluent interface.
+///
+/// This builder simplifies the process of constructing documentation
+/// for parsers with method chaining.
+pub struct DocBuilder {
+    documentation: ParserDocumentation,
+}
+
+impl DocBuilder {
+    /// Create a new documentation builder with the given name and category.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the parser
+    /// * `category` - The category this parser belongs to
+    pub fn new(name: impl Into<String>, category: ParserCategory) -> Self {
+        Self {
+            documentation: ParserDocumentation {
+                name: name.into(),
+                category,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Add a description for the parser.
+    ///
+    /// # Arguments
+    ///
+    /// * `description` - A description of what the parser does
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.documentation.description = description.into();
+        self
+    }
+
+    /// Add an example of valid syntax for the parser.
+    ///
+    /// # Arguments
+    ///
+    /// * `example` - An example string showing valid syntax
+    pub fn example(mut self, example: impl Into<String>) -> Self {
+        self.documentation.examples.push(example.into());
+        self
+    }
+
+    /// Add multiple examples of valid syntax for the parser.
+    ///
+    /// # Arguments
+    ///
+    /// * `examples` - A collection of example strings
+    pub fn examples<S, I>(mut self, examples: I) -> Self
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.documentation
+            .examples
+            .extend(examples.into_iter().map(Into::into));
+        self
+    }
+
+    /// Mark the parser as deprecated with an optional message.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - Optional message explaining the deprecation
+    pub fn deprecated(mut self, message: impl Into<String>) -> Self {
+        self.documentation.deprecated = Some(message.into());
+        self
+    }
+
+    /// Add a related parser reference.
+    ///
+    /// # Arguments
+    ///
+    /// * `parser_name` - The name of a related parser
+    pub fn related_parser(mut self, parser_name: impl Into<String>) -> Self {
+        self.documentation.related_parsers.push(parser_name.into());
+        self
+    }
+
+    /// Add multiple related parser references.
+    ///
+    /// # Arguments
+    ///
+    /// * `parser_names` - A collection of related parser names
+    pub fn related_parsers<S, I>(mut self, parser_names: I) -> Self
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.documentation
+            .related_parsers
+            .extend(parser_names.into_iter().map(Into::into));
+        self
+    }
+
+    /// Build the documentation.
+    pub fn build(self) -> ParserDocumentation {
+        self.documentation
+    }
+}
+
+/// Helper functions for creating documented parsers.
+
+/// Create a documented parser with the provided parser and documentation.
+///
+/// # Arguments
+///
+/// * `parser` - The parser to document
+/// * `documentation` - Documentation metadata for the parser
+pub fn document<P, I, O>(parser: P, documentation: ParserDocumentation) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    DocParser::new(parser, documentation)
+}
+
+/// Create a documented expression parser.
+///
+/// # Arguments
+///
+/// * `parser` - The expression parser to document
+/// * `name` - The name of the parser
+/// * `description` - A description of what the parser does
+pub fn document_expression<P, I, O>(
+    parser: P,
+    name: impl Into<String>,
+    description: impl Into<String>,
+) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    let doc = DocBuilder::new(name, ParserCategory::Expression)
+        .description(description)
+        .build();
+    DocParser::new(parser, doc)
+}
+
+/// Create a documented statement parser.
+///
+/// # Arguments
+///
+/// * `parser` - The statement parser to document
+/// * `name` - The name of the parser
+/// * `description` - A description of what the parser does
+pub fn document_statement<P, I, O>(
+    parser: P,
+    name: impl Into<String>,
+    description: impl Into<String>,
+) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    let doc = DocBuilder::new(name, ParserCategory::Statement)
+        .description(description)
+        .build();
+    DocParser::new(parser, doc)
+}
+
+/// Create a documented handler parser.
+///
+/// # Arguments
+///
+/// * `parser` - The handler parser to document
+/// * `name` - The name of the parser
+/// * `description` - A description of what the parser does
+pub fn document_handler<P, I, O>(
+    parser: P,
+    name: impl Into<String>,
+    description: impl Into<String>,
+) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    let doc = DocBuilder::new(name, ParserCategory::Handler)
+        .description(description)
+        .build();
+    DocParser::new(parser, doc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyzer::combinators::Equal;
+    use crate::analyzer::core::Parser;
+
+    #[test]
+    fn test_doc_parser_delegates_parsing() {
+        // Create a simple parser
+        let parser = Equal::new(42);
+        
+        // Create documentation
+        let documentation = DocBuilder::new("equal_42", ParserCategory::Expression)
+            .description("Parses the integer 42")
+            .build();
+        
+        // Create a documented parser
+        let doc_parser = DocParser::new(parser, documentation);
+        
+        // Test that parsing is correctly delegated
+        let input = &[42, 43, 44];
+        assert_eq!(doc_parser.parse(input, 0), Ok((1, 42)));
+        assert!(doc_parser.parse(input, 1).is_err());
+    }
+
+    #[test]
+    fn test_doc_parser_provides_documentation() {
+        let parser = Equal::new(42);
+        
+        let documentation = DocBuilder::new("equal_42", ParserCategory::Expression)
+            .description("Parses the integer 42")
+            .example("42")
+            .build();
+        
+        let doc_parser = DocParser::new(parser, documentation);
+        
+        // Test that we can access the documentation
+        let doc = doc_parser.documentation();
+        assert_eq!(doc.name, "equal_42");
+        assert_eq!(doc.category, ParserCategory::Expression);
+        assert_eq!(doc.description, "Parses the integer 42");
+        assert_eq!(doc.examples, vec!["42"]);
+    }
+
+    #[test]
+    fn test_doc_builder() {
+        let doc = DocBuilder::new("test_parser", ParserCategory::Expression)
+            .description("A test parser")
+            .example("example 1")
+            .example("example 2")
+            .examples(vec!["example 3", "example 4"])
+            .deprecated("Use new_parser instead")
+            .related_parser("other_parser")
+            .related_parsers(vec!["parser1", "parser2"])
+            .build();
+        
+        assert_eq!(doc.name, "test_parser");
+        assert_eq!(doc.description, "A test parser");
+        assert_eq!(
+            doc.examples,
+            vec!["example 1", "example 2", "example 3", "example 4"]
+        );
+        assert_eq!(doc.deprecated, Some("Use new_parser instead".to_string()));
+        assert_eq!(
+            doc.related_parsers,
+            vec!["other_parser", "parser1", "parser2"]
+        );
+    }
+
+    #[test]
+    fn test_helper_functions() {
+        let parser = Equal::new(42);
+        
+        // Test document_expression
+        let doc_expr = document_expression(
+            parser.clone(),
+            "equal_42",
+            "Parses the integer 42",
+        );
+        assert_eq!(doc_expr.documentation().category, ParserCategory::Expression);
+        
+        // Test document_statement
+        let doc_stmt = document_statement(
+            parser.clone(),
+            "equal_42_stmt",
+            "Parses the integer 42 as a statement",
+        );
+        assert_eq!(doc_stmt.documentation().category, ParserCategory::Statement);
+        
+        // Test document_handler
+        let doc_handler = document_handler(
+            parser.clone(),
+            "equal_42_handler",
+            "Parses the integer 42 as a handler",
+        );
+        assert_eq!(doc_handler.documentation().category, ParserCategory::Handler);
+    }
+}

--- a/kairei-core/src/analyzer/mod.rs
+++ b/kairei-core/src/analyzer/mod.rs
@@ -50,6 +50,6 @@ pub mod prelude;
 pub use core::ParseError;
 pub use core::ParseResult;
 pub use core::Parser;
-pub use doc_parser::{DocParser, DocParserExt, ParserDocumentation, ParserCategory};
+pub use doc_parser::{DocParser, DocParserExt, ParserCategory, ParserDocumentation};
 
 pub use crate::ast;

--- a/kairei-core/src/analyzer/mod.rs
+++ b/kairei-core/src/analyzer/mod.rs
@@ -43,11 +43,13 @@
 
 pub mod combinators;
 pub mod core;
+pub mod doc_parser;
 pub mod parsers;
 pub mod prelude;
 
 pub use core::ParseError;
 pub use core::ParseResult;
 pub use core::Parser;
+pub use doc_parser::{DocParser, DocParserExt, ParserDocumentation, ParserCategory};
 
 pub use crate::ast;

--- a/kairei-core/src/analyzer/prelude.rs
+++ b/kairei-core/src/analyzer/prelude.rs
@@ -519,3 +519,28 @@ where
         .build();
     DocParser::new(parser, doc)
 }
+
+/// Creates a documented definition parser for top-level constructs.
+///
+/// # Arguments
+///
+/// * `parser` - The definition parser to document
+/// * `name` - The name of the parser
+/// * `description` - A description of what the parser does
+///
+/// # Returns
+///
+/// A documented definition parser
+pub fn document_definition<P, I, O>(
+    parser: P,
+    name: impl Into<String>,
+    description: impl Into<String>,
+) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    let doc = DocBuilder::new(name, ParserCategory::Definition)
+        .description(description)
+        .build();
+    DocParser::new(parser, doc)
+}

--- a/kairei-core/src/analyzer/prelude.rs
+++ b/kairei-core/src/analyzer/prelude.rs
@@ -8,6 +8,7 @@
 
 use super::combinators::*;
 use super::core::Parser;
+use super::doc_parser::*;
 
 /// Creates a parser that matches a specific value
 ///
@@ -425,4 +426,96 @@ where
     P: Parser<I, O>,
 {
     Lazy::new(f)
+}
+
+/// Creates a documented parser with the provided parser and documentation.
+///
+/// # Arguments
+///
+/// * `parser` - The parser to document
+/// * `documentation` - Documentation metadata for the parser
+///
+/// # Returns
+///
+/// A parser that delegates parsing to the original parser while providing documentation
+pub fn document<P, I, O>(parser: P, documentation: ParserDocumentation) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    DocParser::new(parser, documentation)
+}
+
+/// Creates a documented expression parser.
+///
+/// # Arguments
+///
+/// * `parser` - The expression parser to document
+/// * `name` - The name of the parser
+/// * `description` - A description of what the parser does
+///
+/// # Returns
+///
+/// A documented expression parser
+pub fn document_expression<P, I, O>(
+    parser: P,
+    name: impl Into<String>,
+    description: impl Into<String>,
+) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    let doc = DocBuilder::new(name, ParserCategory::Expression)
+        .description(description)
+        .build();
+    DocParser::new(parser, doc)
+}
+
+/// Creates a documented statement parser.
+///
+/// # Arguments
+///
+/// * `parser` - The statement parser to document
+/// * `name` - The name of the parser
+/// * `description` - A description of what the parser does
+///
+/// # Returns
+///
+/// A documented statement parser
+pub fn document_statement<P, I, O>(
+    parser: P,
+    name: impl Into<String>,
+    description: impl Into<String>,
+) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    let doc = DocBuilder::new(name, ParserCategory::Statement)
+        .description(description)
+        .build();
+    DocParser::new(parser, doc)
+}
+
+/// Creates a documented handler parser.
+///
+/// # Arguments
+///
+/// * `parser` - The handler parser to document
+/// * `name` - The name of the parser
+/// * `description` - A description of what the parser does
+///
+/// # Returns
+///
+/// A documented handler parser
+pub fn document_handler<P, I, O>(
+    parser: P,
+    name: impl Into<String>,
+    description: impl Into<String>,
+) -> DocParser<P, I, O>
+where
+    P: Parser<I, O>,
+{
+    let doc = DocBuilder::new(name, ParserCategory::Handler)
+        .description(description)
+        .build();
+    DocParser::new(parser, doc)
 }

--- a/kairei-core/tests/doc_parser_integration_test.rs
+++ b/kairei-core/tests/doc_parser_integration_test.rs
@@ -1,0 +1,108 @@
+use kairei_core::analyzer::prelude::*;
+use kairei_core::analyzer::{DocParserExt, ParserCategory, Parser};
+use kairei_core::analyzer::doc_parser::DocBuilder;
+use kairei_core::ast;
+use kairei_core::tokenizer::{token::Token, literal::{Literal, StringLiteral, StringPart}, symbol::Delimiter};
+
+/// Creates a documented parser for the think expression
+fn create_documented_think_parser() -> impl DocParserExt<Token, ast::Expression> {
+    // Create documentation
+    let doc = DocBuilder::new("parse_think", ParserCategory::Expression)
+        .description("Parses a think expression for LLM invocation")
+        .example("think(\"What is the capital of France?\")")
+        .example("think(\"Summarize this text\", text)")
+        .example("think(prompt: \"Generate ideas\", context: data) with { model: \"gpt-4\" }")
+        .build();
+    
+    // Get the parser from the normal parse_think function
+    // For testing, we'll create a simple parser that matches a specific sequence
+    let parser = map(
+        delimited(
+            as_unit(equal(Token::Keyword(kairei_core::tokenizer::keyword::Keyword::Think))),
+            delimited(
+                as_unit(equal(Token::Delimiter(Delimiter::OpenParen))),
+                equal(Token::Literal(Literal::String(StringLiteral::Single(vec![
+                    StringPart::Literal("test".to_string()),
+                ])))),
+                as_unit(equal(Token::Delimiter(Delimiter::CloseParen))),
+            ),
+            zero(()),
+        ),
+        |_| ast::Expression::Literal(ast::Literal::String("test".to_string())),
+    );
+    
+    // Create the documented parser
+    document(parser, doc)
+}
+
+#[test]
+fn test_doc_parser_integration() {
+    // Create the documented parser
+    let parser = create_documented_think_parser();
+    
+    // Test the documentation
+    let doc = parser.documentation();
+    assert_eq!(doc.name, "parse_think");
+    assert_eq!(doc.category, ParserCategory::Expression);
+    assert!(doc.description.contains("think expression"));
+    assert_eq!(doc.examples.len(), 3);
+    
+    // Test the parser functionality
+    let input = &[
+        Token::Keyword(kairei_core::tokenizer::keyword::Keyword::Think),
+        Token::Delimiter(Delimiter::OpenParen),
+        Token::Literal(Literal::String(StringLiteral::Single(vec![
+            StringPart::Literal("test".to_string()),
+        ]))),
+        Token::Delimiter(Delimiter::CloseParen),
+    ];
+    
+    // The parser should still work correctly
+    let result = parser.parse(input, 0);
+    assert!(result.is_ok());
+    
+    let (pos, expr) = result.unwrap();
+    assert_eq!(pos, 4);
+    
+    match expr {
+        ast::Expression::Literal(ast::Literal::String(s)) => {
+            assert_eq!(s, "test");
+        }
+        _ => panic!("Expected string literal"),
+    }
+}
+
+#[test]
+fn test_doc_parser_collection() {
+    // Create a collection of documented parsers
+    let parsers: Vec<Box<dyn DocParserExt<Token, ast::Expression>>> = vec![
+        Box::new(create_documented_think_parser()),
+        // We need to map the integer token to an Expression
+        Box::new(document_expression(
+            map(
+                equal(Token::Literal(Literal::Integer(42))),
+                |_| ast::Expression::Literal(ast::Literal::Integer(42))
+            ),
+            "parse_integer",
+            "Parses an integer literal",
+        )),
+    ];
+    
+    // Check that we can collect documentation from all parsers
+    let mut docs = Vec::new();
+    for parser in &parsers {
+        docs.push(parser.documentation().clone());
+    }
+    
+    assert_eq!(docs.len(), 2);
+    assert_eq!(docs[0].name, "parse_think");
+    assert_eq!(docs[1].name, "parse_integer");
+    
+    // Check that we can filter by category
+    let expression_docs: Vec<_> = docs
+        .iter()
+        .filter(|doc| doc.category == ParserCategory::Expression)
+        .collect();
+    
+    assert_eq!(expression_docs.len(), 2);
+}

--- a/kairei-core/tests/doc_parser_integration_test.rs
+++ b/kairei-core/tests/doc_parser_integration_test.rs
@@ -1,8 +1,12 @@
-use kairei_core::analyzer::prelude::*;
-use kairei_core::analyzer::{DocParserExt, ParserCategory, Parser};
 use kairei_core::analyzer::doc_parser::DocBuilder;
+use kairei_core::analyzer::prelude::*;
+use kairei_core::analyzer::{DocParserExt, Parser, ParserCategory};
 use kairei_core::ast;
-use kairei_core::tokenizer::{token::Token, literal::{Literal, StringLiteral, StringPart}, symbol::Delimiter};
+use kairei_core::tokenizer::{
+    literal::{Literal, StringLiteral, StringPart},
+    symbol::Delimiter,
+    token::Token,
+};
 
 /// Creates a documented parser for the think expression
 fn create_documented_think_parser() -> impl DocParserExt<Token, ast::Expression> {
@@ -13,24 +17,26 @@ fn create_documented_think_parser() -> impl DocParserExt<Token, ast::Expression>
         .example("think(\"Summarize this text\", text)")
         .example("think(prompt: \"Generate ideas\", context: data) with { model: \"gpt-4\" }")
         .build();
-    
+
     // Get the parser from the normal parse_think function
     // For testing, we'll create a simple parser that matches a specific sequence
     let parser = map(
         delimited(
-            as_unit(equal(Token::Keyword(kairei_core::tokenizer::keyword::Keyword::Think))),
+            as_unit(equal(Token::Keyword(
+                kairei_core::tokenizer::keyword::Keyword::Think,
+            ))),
             delimited(
                 as_unit(equal(Token::Delimiter(Delimiter::OpenParen))),
-                equal(Token::Literal(Literal::String(StringLiteral::Single(vec![
-                    StringPart::Literal("test".to_string()),
-                ])))),
+                equal(Token::Literal(Literal::String(StringLiteral::Single(
+                    vec![StringPart::Literal("test".to_string())],
+                )))),
                 as_unit(equal(Token::Delimiter(Delimiter::CloseParen))),
             ),
             zero(()),
         ),
         |_| ast::Expression::Literal(ast::Literal::String("test".to_string())),
     );
-    
+
     // Create the documented parser
     document(parser, doc)
 }
@@ -39,14 +45,14 @@ fn create_documented_think_parser() -> impl DocParserExt<Token, ast::Expression>
 fn test_doc_parser_integration() {
     // Create the documented parser
     let parser = create_documented_think_parser();
-    
+
     // Test the documentation
     let doc = parser.documentation();
     assert_eq!(doc.name, "parse_think");
     assert_eq!(doc.category, ParserCategory::Expression);
     assert!(doc.description.contains("think expression"));
     assert_eq!(doc.examples.len(), 3);
-    
+
     // Test the parser functionality
     let input = &[
         Token::Keyword(kairei_core::tokenizer::keyword::Keyword::Think),
@@ -56,14 +62,14 @@ fn test_doc_parser_integration() {
         ]))),
         Token::Delimiter(Delimiter::CloseParen),
     ];
-    
+
     // The parser should still work correctly
     let result = parser.parse(input, 0);
     assert!(result.is_ok());
-    
+
     let (pos, expr) = result.unwrap();
     assert_eq!(pos, 4);
-    
+
     match expr {
         ast::Expression::Literal(ast::Literal::String(s)) => {
             assert_eq!(s, "test");
@@ -79,30 +85,29 @@ fn test_doc_parser_collection() {
         Box::new(create_documented_think_parser()),
         // We need to map the integer token to an Expression
         Box::new(document_expression(
-            map(
-                equal(Token::Literal(Literal::Integer(42))),
-                |_| ast::Expression::Literal(ast::Literal::Integer(42))
-            ),
+            map(equal(Token::Literal(Literal::Integer(42))), |_| {
+                ast::Expression::Literal(ast::Literal::Integer(42))
+            }),
             "parse_integer",
             "Parses an integer literal",
         )),
     ];
-    
+
     // Check that we can collect documentation from all parsers
     let mut docs = Vec::new();
     for parser in &parsers {
         docs.push(parser.documentation().clone());
     }
-    
+
     assert_eq!(docs.len(), 2);
     assert_eq!(docs[0].name, "parse_think");
     assert_eq!(docs[1].name, "parse_integer");
-    
+
     // Check that we can filter by category
     let expression_docs: Vec<_> = docs
         .iter()
         .filter(|doc| doc.category == ParserCategory::Expression)
         .collect();
-    
+
     assert_eq!(expression_docs.len(), 2);
 }


### PR DESCRIPTION
## Summary
- Implements DocParserExt trait and DocParser wrapper for adding documentation to parsers
- Adds ParserDocumentation struct to store comprehensive metadata
- Provides DocBuilder for fluent documentation creation
- Includes helper functions for different parser categories
- Adds integration tests to validate functionality

## Implementation Details
- **DocParserExt trait**: Extends parsers with documentation capabilities
- **DocParser wrapper**: Delegates parsing to the wrapped parser while providing documentation
- **ParserCategory enum**: Categorizes parsers (Expression, Statement, Handler, etc.)
- **Documentation in prelude**: Makes documentation functions easily accessible

This implementation fulfills the requirements specified in issue #286:
- DocParserExt trait can be applied to existing parsers
- Documentation can be attached without changing parser behavior
- Tests verify the wrapper properly delegates to wrapped parsers
- Example implementations demonstrate usage

This is the first part of the DSL Documentation Generator project that will enable parsers to be self-documenting, leading to more accurate and maintainable documentation.

## Testing
All unit tests and integration tests pass, with new tests specifically for DocParserExt functionality.

Resolves #286

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>