### PR TITLE
Documentation API and CLI Integration

### DIFF
--- a/kairei-http/src/models/docs.rs
+++ b/kairei-http/src/models/docs.rs
@@ -82,3 +82,64 @@ pub struct DocumentationErrorResponse {
     /// Additional details about the error
     pub details: Option<String>,
 }
+
+/// Response containing a map of available documentation
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DocumentationMapResponse {
+    /// API version (matches kairei-core version)
+    pub version: String,
+    /// Available parser categories
+    pub categories: Vec<String>,
+    /// Parser names by category
+    pub parsers_by_category: HashMap<String, Vec<String>>,
+}
+
+/// Request to export documentation
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ExportDocumentationRequest {
+    /// Export format (json, markdown)
+    #[schema(example = "json", default = "json")]
+    pub format: String,
+
+    /// Include version information
+    #[schema(example = "true", default = "true")]
+    pub include_version: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub enum ExportFormat {
+    Json,
+    Markdown,
+}
+
+impl Default for ExportFormat {
+    fn default() -> Self {
+        Self::Json
+    }
+}
+
+impl TryFrom<&str> for ExportFormat {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "json" => Ok(Self::Json),
+            "markdown" => Ok(Self::Markdown),
+            "md" => Ok(Self::Markdown),
+            _ => Err(format!("Invalid export format: {}", value)),
+        }
+    }
+}
+
+/// Response from documentation export
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ExportDocumentationResponse {
+    /// Export format
+    pub format: String,
+
+    /// Documentation content
+    pub content: String,
+
+    /// API version
+    pub version: String,
+}

--- a/kairei-http/src/routes/api/v1/docs.rs
+++ b/kairei-http/src/routes/api/v1/docs.rs
@@ -1,10 +1,14 @@
 //! API routes for DSL documentation.
 
 use crate::handlers::{
-    get_all_documentation, get_category_documentation, get_parser_documentation,
+    export_documentation, get_all_documentation, get_category_documentation, get_documentation_map,
+    get_parser_documentation,
 };
 use crate::server::AppState;
-use axum::{Router, routing::get};
+use axum::{
+    Router,
+    routing::{get, post},
+};
 
 /// Create the documentation routes with state
 pub fn routes() -> Router<AppState> {
@@ -15,6 +19,8 @@ pub fn routes() -> Router<AppState> {
 fn docs_routes() -> Router<AppState> {
     Router::new()
         .route("/dsl", get(get_all_documentation))
+        .route("/dsl/map", get(get_documentation_map))
+        .route("/dsl/export", post(export_documentation))
         .route("/dsl/{category}", get(get_category_documentation))
         .route("/dsl/{category}/{name}", get(get_parser_documentation))
 }


### PR DESCRIPTION
# Documentation API and CLI Integration

This PR adds comprehensive documentation features to the Kairei system, including both API endpoints and CLI commands for accessing and exporting documentation.

## API Changes

### New Documentation Endpoints
- Added `/api/v1/docs/dsl/map` endpoint to retrieve a map of all available documentation
- Added `/api/v1/docs/dsl/export` endpoint to export documentation in different formats (markdown, json)

### API Client Updates
- Added `get_documentation_map()` method to retrieve documentation structure
- Added `export_documentation()` method to export documentation with format options

## CLI Changes

### Command Line Options Consistency
- Renamed `--output` to `--format` for specifying output format (json, yaml, table)
- Updated documentation comments for clarity

### New Documentation Commands
- Added `doc` command with subcommands:
  - `map`: Display documentation structure by category
  - `export`: Export documentation with options:
    - `--format`: Output format (markdown, json)
    - `--version`: Include version information
    - `--output-file`: Output file path (prints to stdout if not specified)

### Test Updates
- Added integration tests for new documentation commands
- Updated existing tests to use the new option names
- Added temporary file path handling in tests

## Benefits

These changes provide:
1. Consistent CLI interface with `--format` used for specifying output format across all commands
2. Clear separation between format specification and file output options
3. Comprehensive documentation access through both API and CLI
4. Multiple export formats for documentation (markdown, json)

All tests pass with these changes, ensuring backward compatibility while improving the user experience.

#290
